### PR TITLE
Add Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.5
+
+RUN apt-get update && apt-get install -y --no-install-recommends librrd-dev net-tools \
+        && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+ADD . /usr/src/app
+
+RUN python manage.py migrate
+
+RUN pip install --no-cache-dir honcho
+CMD ["honcho", "start"]
+

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,4 @@
+collect_server: python collect_server/run_server.py
+collect_listener: python collect_server/run_listener.py
+web: python manage.py runserver 0.0.0.0:8888
+

--- a/common/settings.py
+++ b/common/settings.py
@@ -51,7 +51,7 @@ chart_resolution = 400
 
 #
 # main link settings
-# 
+#
 # remove or add links you want
 #
 main_link = [	('system', '/system'),
@@ -74,6 +74,9 @@ main_link = [	('system', '/system'),
 
 # for arcus_mon
 arcus_zk_addrs = []
+if 'ARCUS_ZK_ADDRESSES' in os.environ:
+    arcus_zk_addrs = os.environ['ARCUS_ZK_ADDRESSES'].split(',')
+
 '''
 # example
 arcus_zk_addrs.append('arcuscloud.yourcompany.com:17288')


### PR DESCRIPTION
Docker is useful for newbies who want to contribute hubblemon.

This Dockerfile is for development environment only. It does following things:
  - installs dependencies (librrd-dev, net-tools for psutil plugin)
  - starts collect_server, collect_listener, web

It could run collect_client inside the container:
```bash
$ docker exec -it <hubblemon container name> bash

# inside the container
$ cd collect_client && python run_client.py
```

The hubblemon container should expose the port 8888 to browse in the host machine.