### PR TITLE
Update arcus.py to import Queue as queue if Python2

### DIFF
--- a/arcus_mon/arcus_driver/arcus.py
+++ b/arcus_mon/arcus_driver/arcus.py
@@ -20,7 +20,12 @@ from kazoo.client import KazooClient
 from threading import Lock
 import hashlib, bisect, re
 import struct, datetime, time
-import queue
+import sys
+
+if sys.version_info[0] < 3:
+    import Queue as queue
+else:
+    import queue
 
 
 g_log = False


### PR DESCRIPTION
Python2인 경우를 확인하여 Queue를 import 하게 수정하였습니다.