### PR TITLE
Dockerfile 수정 및  run_client.py 에 redis 예제 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.4
 
 RUN apt-get update && apt-get install -y --no-install-recommends librrd-dev net-tools \
         && rm -rf /var/lib/apt/lists/*

--- a/collect_client/run_client.py
+++ b/collect_client/run_client.py
@@ -64,6 +64,11 @@ cub = cubrid_stat()
 cub.auto_register()
 c.plugins.append(cub)
 
+# redis stat example
+rds = redis_stat()
+rds.auto_arc_register()
+c.plugins.append(rds)
+
 # jstat stat example
 js = jstat_stat()
 js.auto_register(['java', 'apache', 'catalina'], trace=True)


### PR DESCRIPTION
1. 
Dockerfile 을 이용하여 build 를 했는데 이미지가 생성이 안되었습니다. (ubuntu 14.04)

HTMLPaeseError 는 python 3.5 에서 지원되지 않아 3.4 로 버전을 낮추어 정상적인 도커 이미지를 build 하였습니다.

2.
collect_client/run_client.py 에서 redis_stat 을 import 하고 있지만 사용하고 있는 예제 코드는 없습니다.

