### PR TITLE
Update for django==2.0

### DIFF
--- a/hubblemon/urls.py
+++ b/hubblemon/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
     # url(r'^$', 'hubblemon.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),
 
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^$', chart_page),
     url(r'^graph/', graph_page),
     url(r'^expr/', expr_page),


### PR DESCRIPTION
Django 2.0 released and there were some changes to the `url` function.

in `hubblemon/urls.py`*(line 32)*
```
...
    url(r'^admin/', include(admin.site.urls)),
...
```

It should be fixed as follows.
```
...
    url(r'^admin/', admin.site.urls),
...
```

And this is a pull request to fix it.