### PR TITLE
function name typo fix

### DIFF
--- a/chart/views.py
+++ b/chart/views.py
@@ -777,7 +777,7 @@ def graph_page(request):
 
 	## make view
 	variables = {
-		'main_link': _main_main_link(),
+		'main_link': _make_main_link(),
 		'graph_list': js_graph_list,
 		'graph_data': ret
 	}


### PR DESCRIPTION
_main_main_link -> _make_main_link
함수 이름의 오타로 에러납니다. 오타 수정하였습니다.